### PR TITLE
Remove duplicate style loading

### DIFF
--- a/extension/contentScript.js
+++ b/extension/contentScript.js
@@ -3,11 +3,6 @@
   root.id = 'sgb-root';
   document.body.appendChild(root);
 
-  const link = document.createElement('link');
-  link.rel = 'stylesheet';
-  link.href = chrome.runtime.getURL('style.css');
-  document.head.appendChild(link);
-
   function loadScript(src) {
     return new Promise((resolve) => {
       const s = document.createElement('script');


### PR DESCRIPTION
## Summary
- rely on the manifest to load extension styles
- rebuild extension to ensure style.css remains in the bundle

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683f7367e0fc832397cae6893a3cac81