### PR TITLE
Delay chrome storage save until data loaded

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -3,12 +3,23 @@
 
   function useChromeStorage(key, defaultValue){
     const [value, setValue] = React.useState(defaultValue);
+    const [initialized, setInitialized] = React.useState(false);
+
     React.useEffect(()=>{
       chrome.storage.local.get([key], (res)=>{
-        if(res[key] !== undefined) setValue(res[key]);
+        if(res[key] !== undefined) {
+          setValue(res[key]);
+        }
+        setInitialized(true);
       });
     },[]);
-    React.useEffect(()=>{ chrome.storage.local.set({[key]: value}); },[value]);
+
+    React.useEffect(()=>{
+      if(initialized){
+        chrome.storage.local.set({[key]: value});
+      }
+    },[value, initialized]);
+
     return [value, setValue];
   }
 


### PR DESCRIPTION
## Summary
- prevent overwriting saved settings on initial load
- delay `chrome.storage.local.set` calls in `useChromeStorage` until `chrome.storage.local.get` completes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f7366dd148323a7ac5f5268ae7f94